### PR TITLE
Fixes a null pointer exception if a scheduler isn't supplied to "windowWithTimeOrCount".

### DIFF
--- a/source/raix/src/raix/reactive/AbsObservable.as
+++ b/source/raix/src/raix/reactive/AbsObservable.as
@@ -451,6 +451,8 @@ package raix.reactive
 			{
 				throw new ArgumentError("count must be > 0");
 			}
+			
+			scheduler ||= Scheduler.synchronous;
 
 			var source : IObservable = this;
 			


### PR DESCRIPTION
Fixes a bug in "windowWithTimeOrCount" where a default scheduler isn't assigned if a scheduler isn't supplied.
