### PR TITLE
Feature Request: Additional "targetingOnly" Boolean argument in "Observable.fromEvent" and "Observable.fromEvents".

### DIFF
--- a/source/raix/src/raix/reactive/AbsObservable.as
+++ b/source/raix/src/raix/reactive/AbsObservable.as
@@ -451,6 +451,8 @@ package raix.reactive
 			{
 				throw new ArgumentError("count must be > 0");
 			}
+			
+			scheduler ||= Scheduler.synchronous;
 
 			var source : IObservable = this;
 			

--- a/source/raix/src/raix/reactive/Observable.as
+++ b/source/raix/src/raix/reactive/Observable.as
@@ -551,9 +551,12 @@ package raix.reactive
 		 * @param eventType The valueClass of event dispatched by eventDispatcher. Event will be used if this argument is null.
 		 * @param useCapture Whether to pass useCapture when subscribing to and unsubscribing from the event
 		 * @param priority The priority of the event
+		 * @param targetingOnly Whether to cancel the event at the targeting phase, or allow it to bubble back up the display list.
+		 * This only applies if the event is actually processed in the "targeting" phase, so events handled during the bubbling phase
+		 * won't be affected, even if the IObservable was created with <code>targetingOnly == true</code>
 		 * @return An observable sequence of eventType, or Event if eventType is null
 		 */		
-		public static function fromEvent(eventDispatcher:IEventDispatcher, eventType:String, useCapture:Boolean=false, priority:int=0):IObservable
+		public static function fromEvent(eventDispatcher:IEventDispatcher, eventType:String, useCapture:Boolean=false, priority:int=0, targetingOnly:Boolean=false):IObservable
 		{
 			if (eventDispatcher == null)
 			{
@@ -564,6 +567,11 @@ package raix.reactive
 			{
 				var listener : Function = function(event : Event) : void
 				{
+					if(targetingOnly && event.eventPhase == EventPhase.AT_TARGET)
+					{
+						event.stopPropagation();
+					}
+					
 					observer.onNext(event);
 				};
 				
@@ -584,12 +592,12 @@ package raix.reactive
 		 * @param priority The priority of the event
 		 * @return An observable sequence of commonValueClass, or Event if commonValueClass is null 
 		 */
-		public static function fromEvents(eventDispatcher:IEventDispatcher, eventTypes:Array, useCapture:Boolean=false, priority:int=0):IObservable
+		public static function fromEvents(eventDispatcher:IEventDispatcher, eventTypes:Array, useCapture:Boolean=false, priority:int=0, targetingOnly:Boolean=false):IObservable
 		{
 			return Observable.fromArray(eventTypes)
 					.mapMany(function(eventType : String) : IObservable
 					{
-						return fromEvent(eventDispatcher, eventType, useCapture, priority);
+						return fromEvent(eventDispatcher, eventType, useCapture, priority, targetingOnly);
 					});
 		}
 		

--- a/source/raix/src/raix/reactive/Observable.as
+++ b/source/raix/src/raix/reactive/Observable.as
@@ -567,12 +567,17 @@ package raix.reactive
 			{
 				var listener : Function = function(event : Event) : void
 				{
-					if(targetingOnly && event.eventPhase == EventPhase.AT_TARGET)
+					if(targetingOnly == true)
 					{
-						event.stopPropagation();
+						if(event.eventPhase == EventPhase.AT_TARGET)
+						{
+							observer.onNext(event);
+						}
 					}
-					
-					observer.onNext(event);
+					else
+					{
+						observer.onNext(event);
+					}
 				};
 				
 				eventDispatcher.addEventListener(eventType, listener, useCapture, priority);


### PR DESCRIPTION
The "targetingOnly" argument stops the event from bubbling if it's observed during the targeting phase.

Take the following example (assume "this" is the Stage root instance):

```
const child:DisplayObject = addChild(new Sprite());
const childObs:IObservable = Observable.fromEvent(child, MouseEvent.MOUSE_DOWN);
const stageObs:IObservable = Observable.fromEvent(this, MouseEvent.MOUSE_DOWN);

childObs.subscribe(function(me:MouseEvent):void {
    trace('child down');
});
stageObs.subscribe(function(me:MouseEvent):void {
    trace('stage down');
});

child.dispatchEvent(new MouseEvent(MouseEvent.MOUSE_DOWN));
```

When the event is dispatched on the `child` instance, `stageObs` processes the event in its bubbling phase.

I could construct `childObs` to stop the propagation of all its events:

```
const childObs:IObservable = Observable.
                             fromEvent(child, MouseEvent.MOUSE_DOWN).
                             peek(function(me:MouseEvent):void {
                                if(me.eventPhase == EventPhase.AT_TARGET) me.stopPropagation();
                             });
```

or I could construct `stageObs` to filter out events it observes that aren't at the targeting phase:

```
const stageObs:IObservable = Observable.
                             fromEvent(this, MouseEvent.MOUSE_DOWN).
                             filter(function(me:MouseEvent):Boolean {
                                return me.eventPhase == EventPhase.AT_TARGET;
                             });
```

Either solution requires extra coding which becomes tedious if you have many parents that need to be shielded from the bubbling phase. If this were C#, I'd write an extension method. Since it isn't, this seems the least invasive place to add this feature.

Alternatively, I could see adding a `cancelBubbling()` function on `IObservable`, but since it's `Event`-specific and not necessarily related to `Observables`, I went with this instead.
